### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/rake-runner-agent/src/jetbrains/buildServer/agent/rakerunner/utils/ShellScriptRunnerUtil.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/rakerunner/utils/ShellScriptRunnerUtil.java
@@ -36,7 +36,7 @@ public class ShellScriptRunnerUtil {
     try {
       process.waitFor();
     } catch (InterruptedException e) {
-      LOG.error("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e );
+      LOG.error("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e);
     }
   }
 }

--- a/rake-runner-agent/src/jetbrains/buildServer/agent/rakerunner/utils/ShellScriptRunnerUtil.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/rakerunner/utils/ShellScriptRunnerUtil.java
@@ -36,7 +36,7 @@ public class ShellScriptRunnerUtil {
     try {
       process.waitFor();
     } catch (InterruptedException e) {
-      LOG.error("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e.toString());
+      LOG.error("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e );
     }
   }
 }

--- a/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/impl/RubySdkImpl.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/impl/RubySdkImpl.java
@@ -64,7 +64,7 @@ public class RubySdkImpl implements RubySdk {
       if (SystemInfo.isWindows) {
         executableName.append(".exe");
       }
-      myExecutablePath = new File(myHome, "bin" + File.separator + executableName.toString());
+      myExecutablePath = new File(myHome, "bin" + File.separator + executableName );
     }
   }
 

--- a/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/impl/RubySdkImpl.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/impl/RubySdkImpl.java
@@ -64,7 +64,7 @@ public class RubySdkImpl implements RubySdk {
       if (SystemInfo.isWindows) {
         executableName.append(".exe");
       }
-      myExecutablePath = new File(myHome, "bin" + File.separator + executableName );
+      myExecutablePath = new File(myHome, "bin" + File.separator + executableName);
     }
   }
 

--- a/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rvm/RVMCommandLineProcessor.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rvm/RVMCommandLineProcessor.java
@@ -150,7 +150,7 @@ public class RVMCommandLineProcessor implements BuildCommandLineProcessor {
 
       setPermissions(script, SCRIPT_PERMISSIONS); // script needs to be made executable for all (chmod a+x)
     } catch (IOException e) {
-      throw new RunBuildException("Failed to create temp file, error: " + e );
+      throw new RunBuildException("Failed to create temp file, error: " + e);
     }
     return script;
   }

--- a/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rvm/RVMCommandLineProcessor.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rvm/RVMCommandLineProcessor.java
@@ -150,7 +150,7 @@ public class RVMCommandLineProcessor implements BuildCommandLineProcessor {
 
       setPermissions(script, SCRIPT_PERMISSIONS); // script needs to be made executable for all (chmod a+x)
     } catch (IOException e) {
-      throw new RunBuildException("Failed to create temp file, error: " + e.toString());
+      throw new RunBuildException("Failed to create temp file, error: " + e );
     }
     return script;
   }
@@ -160,7 +160,7 @@ public class RVMCommandLineProcessor implements BuildCommandLineProcessor {
     try {
       process.waitFor();
     } catch (InterruptedException e) {
-      Loggers.AGENT.warn("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e.toString());
+      Loggers.AGENT.warn("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e );
     }
   }
 

--- a/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rvm/RVMCommandLineProcessor.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rvm/RVMCommandLineProcessor.java
@@ -160,7 +160,7 @@ public class RVMCommandLineProcessor implements BuildCommandLineProcessor {
     try {
       process.waitFor();
     } catch (InterruptedException e) {
-      Loggers.AGENT.warn("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e );
+      Loggers.AGENT.warn("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e);
     }
   }
 


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:-802048929 -->
<!-- fingerprint:1828035200 -->
<!-- fingerprint:856213524 -->
<!-- fingerprint:956435629 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (4)
