### PR TITLE
refactor: refactor bad smell Non-Protected-Constructor-in-Abstract-Class

### DIFF
--- a/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rbenv/RbEnvShellRunner.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rbenv/RbEnvShellRunner.java
@@ -35,7 +35,7 @@ public abstract class RbEnvShellRunner implements ShellScriptRunner {
   private static final Logger LOG = Logger.getInstance(RbEnvShellRunner.class.getName());
   private final InstalledRbEnv myRbEnv;
 
-  public RbEnvShellRunner(@NotNull final InstalledRbEnv rbEnv) {
+  protected RbEnvShellRunner(@NotNull final InstalledRbEnv rbEnv) {
     myRbEnv = rbEnv;
   }
 


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## Non-Protected-Constructor-in-Abstract-Class
A non-protected constructor in an abstract class is not needed because only subclasses can be instantiated
<!-- fingerprint:772118980 -->
# Repairing Code Style Issues
* Non-Protected-Constructor-in-Abstract-Class (1)
