### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/rake-runner-agent/src/jetbrains/buildServer/agent/rakerunner/utils/ShellScriptRunnerUtil.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/rakerunner/utils/ShellScriptRunnerUtil.java
@@ -36,7 +36,7 @@ public class ShellScriptRunnerUtil {
     try {
       process.waitFor();
     } catch (InterruptedException e) {
-      LOG.error("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e.toString());
+      LOG.error("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e);
     }
   }
 }

--- a/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/impl/RubySdkImpl.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/impl/RubySdkImpl.java
@@ -64,7 +64,7 @@ public class RubySdkImpl implements RubySdk {
       if (SystemInfo.isWindows) {
         executableName.append(".exe");
       }
-      myExecutablePath = new File(myHome, "bin" + File.separator + executableName.toString());
+      myExecutablePath = new File(myHome, "bin" + File.separator + executableName);
     }
   }
 

--- a/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rvm/RVMCommandLineProcessor.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rvm/RVMCommandLineProcessor.java
@@ -150,7 +150,7 @@ public class RVMCommandLineProcessor implements BuildCommandLineProcessor {
 
       setPermissions(script, SCRIPT_PERMISSIONS); // script needs to be made executable for all (chmod a+x)
     } catch (IOException e) {
-      throw new RunBuildException("Failed to create temp file, error: " + e.toString());
+      throw new RunBuildException("Failed to create temp file, error: " + e);
     }
     return script;
   }
@@ -160,7 +160,7 @@ public class RVMCommandLineProcessor implements BuildCommandLineProcessor {
     try {
       process.waitFor();
     } catch (InterruptedException e) {
-      Loggers.AGENT.warn("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e.toString());
+      Loggers.AGENT.warn("Failed to execute chmod " + perms + " " + script.getAbsolutePath() + ", error: " + e);
     }
   }
 
@@ -225,3 +225,5 @@ public class RVMCommandLineProcessor implements BuildCommandLineProcessor {
     });
   }
 }
+
+

--- a/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rvm/RVMCommandLineProcessor.java
+++ b/rake-runner-agent/src/jetbrains/buildServer/agent/ruby/rvm/RVMCommandLineProcessor.java
@@ -225,5 +225,3 @@ public class RVMCommandLineProcessor implements BuildCommandLineProcessor {
     });
   }
 }
-
-


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:Qodana-teamcity-rake-UnnecessaryToStringCall-ebc8105c87939abdec5600104e5c693e91078fc6-sl:153-el:0-sc:77-ec:0-co:5717-cl:8 -->
<!-- fingerprint:Qodana-teamcity-rake-UnnecessaryToStringCall-ebc8105c87939abdec5600104e5c693e91078fc6-sl:67-el:0-sc:83-ec:0-co:2407-cl:8 -->
<!-- fingerprint:Qodana-teamcity-rake-UnnecessaryToStringCall-ebc8105c87939abdec5600104e5c693e91078fc6-sl:39-el:0-sc:103-ec:0-co:1507-cl:8 -->
<!-- fingerprint:Qodana-teamcity-rake-UnnecessaryToStringCall-ebc8105c87939abdec5600104e5c693e91078fc6-sl:163-el:0-sc:112-ec:0-co:6165-cl:8 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (4)
